### PR TITLE
Include chd3backend directory for backend deployment

### DIFF
--- a/ansible/roles/wck-app-config/files/deployment-scripts/backend_deployment.yml
+++ b/ansible/roles/wck-app-config/files/deployment-scripts/backend_deployment.yml
@@ -12,6 +12,8 @@
       directories:
         - "DATA"
         - "MODULES"
+        - "CHSQL"
+        - "COMMONSQL"
         - "bcdbackend"
         - "chd3backend"
         - "efbackend"

--- a/ansible/roles/wck-app-config/files/deployment-scripts/backend_deployment.yml
+++ b/ansible/roles/wck-app-config/files/deployment-scripts/backend_deployment.yml
@@ -12,9 +12,8 @@
       directories:
         - "DATA"
         - "MODULES"
-        - "CHSQL"
-        - "COMMONSQL"
         - "bcdbackend"
+        - "chd3backend"
         - "efbackend"
         - "conf"
       config_files:


### PR DESCRIPTION
Updated backend deployment script to additionally deploy the `chd3backend` scripts directory